### PR TITLE
Fixed issue in preprovision.ps1 using [ instead of (

### DIFF
--- a/.azd/hooks/preprovision.ps1
+++ b/.azd/hooks/preprovision.ps1
@@ -3,14 +3,14 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 # Run script to generate an `env-vars.json` file used by the infra scripts
 & $(Join-Path $scriptDir "../scripts/create-infra-env-vars.ps1")
 
-if [ -z $AZURE_ENV_NAME ]; then
+if (-not $env:AZURE_ENV_NAME) {
     # The Azure environment hasn't been set yet. Check if there's a directory under .azure and use that. Otherwise, prompt for one.
-    num_envs=$(ls .azure/ | grep -v -e .gitignore -e config.json | wc -l)
-    if [ $num_envs = 1 ];then
-        export AZURE_ENV_NAME=`ls .azure/ | grep -v -e .gitignore -e config.json | sed -e 's/\///'`
-    else
-        echo -n "Unable to determine AZURE_ENV_NAME, please provide it: "
-        read value
-        export AZURE_ENV_NAME=$value
-    fi
-fi
+    $azureDir = Join-Path $scriptDir "../../.azure"
+    $envDirs = Get-ChildItem -Path $azureDir -Directory | Where-Object { $_.Name -notin @('.gitignore', 'config.json') }
+
+    if ($envDirs.Count -eq 1) {
+        $env:AZURE_ENV_NAME = $envDirs[0].Name
+    } else {
+        $env:AZURE_ENV_NAME = Read-Host "Unable to determine AZURE_ENV_NAME, please provide it"
+    }
+}


### PR DESCRIPTION
## Problem

Fixes a bug in preprovision.ps1 that used bash syntax instead of PowerShell. 

## Solution

Asked the Cursor AI to rewrite the file to use PowerShell syntax.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

